### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,6 +33,8 @@ jobs:
           name: Ballerina Internal Log
           path: java.jdbc-ballerina/ballerina-internal.log
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Archive Code Coverage JSON
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,9 @@ jobs:
           name: Ballerina Internal Log Linux
           path: java.jdbc-ballerina/ballerina-internal.log
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        if:  github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v1
       - name: Archive Code Coverage JSON
         uses: actions/upload-artifact@v2
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   require_ci_to_pass: no
 
 fixes:
-  - "ballerina/java.jdbc/*/::java.jdbc-ballerina/"
+  - "ballerinax/java$0046jdbc/*/::java.jdbc-ballerina/"
 
 ignore:
   - "**/tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: no
+
+fixes:
+  - "ballerina/java.jdbc/*/::java.jdbc-ballerina/"
+
+ignore:
+  - "**/tests"


### PR DESCRIPTION
## Purpose
>  Introducing Codecov code coverage report publishing to the jdbc repository

## Goals
> Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR.

## Approach
> A new job is inserted to Pull request GitHub actions that publishes the XML report to Codecov.
    These jobs trigger on merge to master or pull request and CodeCov generates a descriptive code coverage report.
    Codecov also adds comments to any PR made based on the code coverage changes between commits