### PR TITLE
Fix plugin crash when variable is passed for `ConnectionPool`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Release JDBC module on Ballerina 2201.0.0 distribution
+- [Fix Compiler plugin crash when variable is passed for `sql:ConnectionPool`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2536)
 
 ## [1.2.0] - 2021-12-13
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/java/jdbc/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/java/jdbc/compiler/CompilerPluginTest.java
@@ -104,4 +104,17 @@ public class CompilerPluginTest {
             Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
         });
     }
+
+    @Test
+    public void testSQLConnectionPoolFieldsInNewExpressionWVariables() {
+        Package currentPackage = loadPackage("sample3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
+
+        Assert.assertEquals(availableErrors, 0);
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "jdbc_test"
+name = "sample3"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/java.jdbc;
+
+public function main() returns error? {
+
+    int connectionNum = 5;
+    int connectionNumInvalid = -5;
+
+    jdbc:Client dbClient1 = check new("url", connectionPool = {maxOpenConnections: connectionNum});
+    check dbClient1.close();
+
+    jdbc:Client dbClient2 = check new("url", (), (), {}, {maxOpenConnections: connectionNumInvalid});
+    check dbClient2.close();
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/java/jdbc/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/java/jdbc/compiler/analyzer/InitializerParamAnalyzer.java
@@ -99,7 +99,7 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
             ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
             switch (name) {
                 case Constants.ConnectionPool.MAX_OPEN_CONNECTIONS:
-                    int maxOpenConnections = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    int maxOpenConnections = Integer.parseInt(getTerminalNodeValue(valueNode, "1"));
                     if (maxOpenConnections < 1) {
                         DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_101.getCode(), SQL_101.getMessage(),
                                 SQL_101.getSeverity());
@@ -110,7 +110,7 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
                     }
                     break;
                 case Constants.ConnectionPool.MIN_IDLE_CONNECTIONS:
-                    int minIdleConnection = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    int minIdleConnection = Integer.parseInt(getTerminalNodeValue(valueNode, "0"));
                     if (minIdleConnection < 0) {
                         DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_102.getCode(), SQL_102.getMessage(),
                                 SQL_102.getSeverity());
@@ -120,7 +120,7 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
                     }
                     break;
                 case Constants.ConnectionPool.MAX_CONNECTION_LIFE_TIME:
-                    float maxConnectionTime = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    float maxConnectionTime = Float.parseFloat(getTerminalNodeValue(valueNode, "30"));
                     if (maxConnectionTime < 30) {
                         DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_103.getCode(), SQL_103.getMessage(),
                                 SQL_103.getSeverity());
@@ -136,15 +136,16 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
         }
     }
 
-    private String getTerminalNodeValue(Node valueNode) {
-        String value;
+    private String getTerminalNodeValue(Node valueNode, String defaultValue) {
+        String value = defaultValue;
         if (valueNode instanceof BasicLiteralNode) {
             value = ((BasicLiteralNode) valueNode).literalToken().text();
-        } else {
+        } else if (valueNode instanceof UnaryExpressionNode) {
             UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
             value = unaryExpressionNode.unaryOperator() +
                     ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
         }
+        // Currently we cannot process values from variables, this needs code flow analysis
         return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
     }
 


### PR DESCRIPTION
## Purpose
$subject

Part of https://github.com/ballerina-platform/ballerina-standard-library/issues/2536

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests