### PR TITLE
Update H2 driver version to 2.1.212

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -16,5 +16,5 @@ path = "../native/build/libs/java.jdbc-native-1.4.0-SNAPSHOT.jar"
 path = "./lib/sql-native-1.4.0-20220324-122700-70834a7.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/h2-2.0.206.jar"
+path = "./lib/h2-2.1.212.jar"
 scope = "testOnly"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.3"
+version = "1.0.4"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/tests/error.bal
+++ b/ballerina/tests/error.bal
@@ -34,8 +34,7 @@ function TestAuthenticationError() {
     test:assertTrue(dbClient is sql:ApplicationError);
     error sqlerror = <error>dbClient;
     test:assertTrue(strings:includes(sqlerror.message(), "Error in SQL connector configuration: Failed to " +
-                "initialize pool: Wrong user name or password [28000-212] Caused by :Wrong user name or password " +
-                "[28000-212]"), sqlerror.message());
+                "initialize pool: Wrong user name or password"), sqlerror.message());
 }
 
 @test:Config {

--- a/ballerina/tests/error.bal
+++ b/ballerina/tests/error.bal
@@ -34,8 +34,8 @@ function TestAuthenticationError() {
     test:assertTrue(dbClient is sql:ApplicationError);
     error sqlerror = <error>dbClient;
     test:assertTrue(strings:includes(sqlerror.message(), "Error in SQL connector configuration: Failed to " +
-                "initialize pool: Wrong user name or password [28000-206] Caused by :Wrong user name or password " +
-                "[28000-206]"), sqlerror.message());
+                "initialize pool: Wrong user name or password [28000-212] Caused by :Wrong user name or password " +
+                "[28000-212]"), sqlerror.message());
 }
 
 @test:Config {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ underCouchDownloadVersion=4.0.4
 researchgateReleaseVersion=2.8.0
 ballerinaGradlePluginVersion=0.14.1
 testngVersion=7.4.0
-h2DriverVersion=2.0.206
+h2DriverVersion=2.1.212
 
 ballerinaLangVersion=2201.0.1
 


### PR DESCRIPTION
## Purpose
$subject 

This was done as the [previous H2 driver version](https://mvnrepository.com/artifact/com.h2database/h2/2.0.206) had a [security vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23221).

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [x] Added tests