### PR TITLE
Defer H2 vulnerability report

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# H2 Driver defer this month as its a false positive
+ CVE-2022-45868 exp:2022-12-31


### PR DESCRIPTION
## Purpose
Defer H2 vulnerability, till fixed version is released. 

Additionally this is a false positive since H2 console is not used in this connector

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
