### PR TITLE
Defer H2 driver vulnerability

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,2 @@
-# H2 Driver defer this month as its a false positive
- CVE-2022-45868 exp:2022-12-31
+# H2 Driver defer until 30th June 2023 as it is a false positive
+ CVE-2022-45868 exp:2023-06-30


### PR DESCRIPTION
## Purpose
$subject

Deferring this vulnerability as it is not valid.
```
The web-based admin console in H2 Database Engine through 2.1.214 can be started via the CLI with the argument -webAdminPassword, which allows the user to specify the password in cleartext for the web admin console. Consequently, a local user (or an attacker that has obtained local access through some means) would be able to discover the password by listing processes and their arguments. NOTE: the vendor states This is not a vulnerability of H2 Console … Passwords should never be passed on the command line and every qualified DBA or system administrator is expected to know that.
```

Github Advisory: https://github.com/advisories/GHSA-22wj-vf5f-wrvj

Related: https://github.com/h2database/h2database/issues/3686#issuecomment-1333917904